### PR TITLE
Custom callback fn

### DIFF
--- a/src/curly.nim
+++ b/src/curly.nim
@@ -879,7 +879,7 @@ proc makeRequest*(
   # Setup writers
   var headerWrap, bodyWrap: StringWrap
   if (callback != nil):
-    discard curl.easy_setopt(OPT_WRITEDATA, callback.addr)
+    discard curl.easy_setopt(OPT_WRITEDATA, callback.unsafeAddr)
     discard curl.easy_setopt(OPT_WRITEFUNCTION, curlCallbackFn)
   else:
     discard curl.easy_setopt(OPT_WRITEDATA, bodyWrap.addr)

--- a/src/curly.nim
+++ b/src/curly.nim
@@ -139,9 +139,10 @@ proc curlCallbackFn(
   callbackFn: pointer
 ): int {.cdecl.} =
   let cb = cast[ptr CallbackFn](callbackFn)
-  echo "foo"
-  cb[]($buffer)
-  echo "bar"
+  var outbuf = ""
+  outbuf.setLen(size * count)
+  copyMem(outbuf[0].addr, buffer, size * count)
+  cb[](outbuf)
   result = size * count
 
 {.pop.}
@@ -877,7 +878,6 @@ proc makeRequest*(
 
   # Setup writers
   var headerWrap, bodyWrap: StringWrap
-  echo "callback " & $(callback != nil)
   if (callback != nil):
     discard curl.easy_setopt(OPT_WRITEDATA, callback.addr)
     discard curl.easy_setopt(OPT_WRITEFUNCTION, curlCallbackFn)


### PR DESCRIPTION

- Use case is to be able to stream chatGPT api responses
- I wanted a way to be able to specify a custom callback function instead of buffering the entire response
- not sure if this is the best way to accomplish this? but it's at least working.