### PR TITLE
1.1.0, streaming response body support

### DIFF
--- a/curly.nimble
+++ b/curly.nimble
@@ -1,4 +1,4 @@
-version     = "1.0.1"
+version     = "1.1.0"
 author      = "Ryan Oldenburg"
 description = "An easy to use and efficient thread-ready HTTP client"
 license     = "MIT"

--- a/src/curly.nim
+++ b/src/curly.nim
@@ -279,7 +279,6 @@ proc threadProc(curl: Curly) {.raises: [].} =
         deinitCond(request.streamState.get.cond)
         destroy request.waitGroup
         destroy request
-        echo "FREED"
       else:
         let easyHandle = curl.availableEasyHandles.popFirst()
 

--- a/src/curly.nim
+++ b/src/curly.nim
@@ -271,10 +271,11 @@ proc threadProc(curl: Curly) {.raises: [].} =
     for request in dequeued:
       if request.easyHandle != nil:
         # This request was added to the queue to be canceled / freed
-        discard multi_remove_handle(curl.multiHandle, request.easyHandle)
-        curl.inFlight.del(request.easyHandle)
-        easy_reset(request.easyHandle)
-        curl.availableEasyHandles.addLast(request.easyHandle)
+        if request.easyHandle in curl.inFlight:
+          discard multi_remove_handle(curl.multiHandle, request.easyHandle)
+          curl.inFlight.del(request.easyHandle)
+          easy_reset(request.easyHandle)
+          curl.availableEasyHandles.addLast(request.easyHandle)
         deinitLock(request.streamState.get.lock)
         deinitCond(request.streamState.get.cond)
         destroy request.waitGroup

--- a/src/curly.nim
+++ b/src/curly.nim
@@ -90,6 +90,7 @@ type
     pslistForLibcurl: Pslist
     responseHeadersForLibcurl: string
     responseBodyForLibcurl: string
+    easyHandle: PCurl
     response: Response
     error: string
 
@@ -226,6 +227,8 @@ proc threadProc(curl: Curly) {.raises: [].} =
 
     for request in dequeued:
       let easyHandle = curl.availableEasyHandles.popFirst()
+
+      request.easyHandle = easyHandle
 
       discard easyHandle.easy_setopt(OPT_URL, request.url.cstring)
       discard easyHandle.easy_setopt(OPT_CUSTOMREQUEST, request.verb.cstring)

--- a/tests/test_responsestream.nim
+++ b/tests/test_responsestream.nim
@@ -1,0 +1,20 @@
+import curly
+
+let curl = newCurly()
+
+let stream = curl.request("GET", "https://sse.dev/test", timeout = 5)
+
+echo stream.code
+echo stream.headers
+
+try:
+  while true:
+    var buffer: string
+    let bytesRead = stream.read(buffer)
+    if bytesRead == 0:
+      break
+    echo buffer
+finally:
+  stream.close()
+
+echo "DONE"

--- a/tests/test_responsestream.nim
+++ b/tests/test_responsestream.nim
@@ -2,7 +2,8 @@ import curly
 
 let curl = newCurly()
 
-let stream = curl.request("GET", "https://sse.dev/test", timeout = 5)
+# let stream = curl.request("GET", "https://sse.dev/test", timeout = 5)
+let stream = curl.request("GET", "https://www.google.com")
 
 echo stream.code
 echo stream.headers


### PR DESCRIPTION
```nim
import curly

let curl = newCurly()

let stream = curl.request("GET", "https://sse.dev/test", timeout = 5)

echo stream.code
echo stream.headers

try:
  while true:
    var buffer: string
    let bytesRead = stream.read(buffer)
    if bytesRead == 0:
      break
    echo buffer
finally:
  stream.close()

echo "DONE"
```

* no callbacks
* get http status code, response headers, final url etc easily before committing to reading the body
* stream body in chucks with your own buffer (will append if buffer already has data in it)

If `curl.request` returns a stream to you (the call does not throw an exception), then you must call `close` on the stream when you are done.

Calling `close` is ok after a stream has been fully read or at any time before that to end a stream early.

Calling `close` is a dealloc call so calling close multiple times is not ok.

Calling `close` is necessary because the internal Curly thread handling the requests with libcurl has no way of knowing when you don't care about the request anymore.

The meaning of `timeout` is as follows: the stream must open (all headers received) within that number of seconds. After the headers have been received, `curl.request` returns a stream. Some number of bytes must arrive within the `timeout` seconds interval since the last `read`, or the stream will raise an exception from `read` as a timeout.